### PR TITLE
🐛 (ci/cd): fix trailing whitespace

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,7 +58,7 @@ jobs:
           push-to-registry: true
       
       - name: Update README
-        run: echo -e "# Custom Image Template \n\n \`\`\`$DOCKER_METADATA_OUTPUT_TAGS \`\`\` \n\n" > README.md
+        run: echo -e "# Custom Image Template \n\n \`\`\`$DOCKER_METADATA_OUTPUT_TAGS\`\`\` \n\n" > README.md
         
       - name: Commit changes
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
Fix trailing whitespace in link causing issues with fast copy in Jupyter interface